### PR TITLE
[crash-reporter] Replace ssu library dependency with systemsettings. JB#57126

### DIFF
--- a/rpm/crash-reporter.spec
+++ b/rpm/crash-reporter.spec
@@ -9,7 +9,6 @@ BuildRequires:          qt5-qtdeclarative-devel
 BuildRequires:          qt5-qtgui-devel
 BuildRequires:          qt5-qtnetwork-devel
 BuildRequires:          qt5-qttools-linguist
-BuildRequires:          ssu-devel
 BuildRequires:          pkgconfig(dbus-1)
 BuildRequires:          pkgconfig(libiphb)
 BuildRequires:          pkgconfig(libudev)
@@ -17,6 +16,7 @@ BuildRequires:          pkgconfig(libsystemd)
 BuildRequires:          pkgconfig(mce)
 BuildRequires:          pkgconfig(qt5-boostable)
 BuildRequires:          pkgconfig(nemonotifications-qt5)
+BuildRequires:          pkgconfig(systemsettings)
 BuildRequires:          pkgconfig(usb-moded-qt5)
 BuildRequires:          pkgconfig(systemd)
 BuildRequires:          oneshot

--- a/src/libs/libs.pro
+++ b/src/libs/libs.pro
@@ -35,12 +35,11 @@ QT = \
 
 CONFIG += link_pkgconfig
 PKGCONFIG += mce \
-             usb-moded-qt5
+             usb-moded-qt5 \
+             nemonotifications-qt5 \
+             systemsettings
 
 DEFINES += CREPORTER_EXPORTS
-
-CONFIG += link_pkgconfig
-PKGCONFIG += nemonotifications-qt5
 
 message(Building architecture: $$system(uname -m))
 
@@ -109,8 +108,6 @@ HEADERS += $$PUBLIC_HEADERS \
             httpclient/creporteruploadengine_p.h \
             settings/creportersettingsbase_p.h \
             settings/creportersettingsinit_p.h \
-
-LIBS += -lssu
 
 TARGET = $$qtLibraryTarget(crashreporter)
 

--- a/src/libs/utils/creporterutils.cpp
+++ b/src/libs/utils/creporterutils.cpp
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 
 #ifndef CREPORTER_UNIT_TEST
-#include <ssudeviceinfo.h>
+#include <deviceinfo.h>
 #endif
 
 #include <QDebug>
@@ -194,7 +194,7 @@ QString CReporterUtils::deviceUid()
     reply.waitForFinished();
     if (reply.isError()) {
         qCWarning(cr) << "DBus unavailable, UUID might be incorrect.";
-        return SsuDeviceInfo().deviceUid();
+        return DeviceInfo(true).deviceUid();
     } else {
         return reply.value();
     }
@@ -206,7 +206,7 @@ QString CReporterUtils::deviceUid()
 QString CReporterUtils::deviceModel()
 {
 #ifndef CREPORTER_UNIT_TEST
-    return SsuDeviceInfo().deviceModel();
+    return DeviceInfo(true).model();
 #else
     return "Device";
 #endif


### PR DESCRIPTION
Phasing out device information from ssu. Better not link with that unless really needing repository information.