### PR TITLE
[crashreporter] Remove bad & unnecessary string conversion. JB#63070

### DIFF
--- a/src/libs/coredir/creportercoredir.cpp
+++ b/src/libs/coredir/creportercoredir.cpp
@@ -119,8 +119,8 @@ QString CReporterCoreDir::checkDirectoryForCores()
         iter.next();
         fi = iter.fileInfo();
 
-        if (!d->coresAtDirectory.contains(fi.fileName()) &&
-                CReporterUtils::validateCore(fi.fileName())) {
+        if (!d->coresAtDirectory.contains(fi.fileName())
+                && CReporterUtils::validateCore(fi.fileName())) {
             // This is valid rich core file, which hasn't been processed before.
             d->coresAtDirectory << fi.fileName();
             coreFilePath = fi.absoluteFilePath();
@@ -152,7 +152,7 @@ void CReporterCoreDir::createCoreDirectory()
             if (coreRoot.exists(d->directory.left(d->directory.lastIndexOf('/')))
                     && coreRoot.mkdir(d->directory)) {
                 qCDebug(cr) << "Created directory:" << d->directory;
-                chmod(CReporterUtils::qstringToChar(d->directory), FILE_PERMISSION);
+                chmod(qPrintable(d->directory), FILE_PERMISSION);
             } else {
                 qCWarning(cr) << "Error while creating directory:" << d->directory;
             }

--- a/src/libs/utils/creporterutils.cpp
+++ b/src/libs/utils/creporterutils.cpp
@@ -72,11 +72,6 @@ bool CReporterUtils::validateCore(const QString &path)
             path.endsWith(coreSuffixRcore, Qt::CaseInsensitive));
 }
 
-char *CReporterUtils::qstringToChar(const QString &str)
-{
-    return str.toLatin1().data();
-}
-
 bool CReporterUtils::isMounted(const QString &path)
 {
 #if defined(CREPORTER_SDK_HOST) || defined(CREPORTER_UNIT_TEST)
@@ -88,7 +83,7 @@ bool CReporterUtils::isMounted(const QString &path)
     struct stat st;
     memset(&st, 0, sizeof(st));
 
-    if (stat(CReporterUtils::qstringToChar(path), &st) == 0) {
+    if (stat(qPrintable(path), &st) == 0) {
         qCDebug(cr) << "Path:" << path << "is mounted. Device ID:" << st.st_dev;
         return true;
     }
@@ -171,7 +166,7 @@ bool CReporterUtils::appendToLzo(const QString &text, const QString &filePath)
 
     // Append to *.lzo.
     QString cmd = QString("/usr/bin/lzop -c %1 >> %2").arg(richCoreTmpNoteFile).arg(filePath) ;
-    int res = system(qstringToChar(cmd));
+    int res = system(qPrintable(cmd));
     qCDebug(cr) << "System returned:"  << res;
 
     // Remove temp file.

--- a/src/libs/utils/creporterutils.h
+++ b/src/libs/utils/creporterutils.h
@@ -59,14 +59,6 @@ public:
     static bool validateCore(const QString &path);
 
     /*!
-     * @brief This function converts QString to char* format.
-     *
-     * @param str string to convert.
-     * @return string in char* format.
-     */
-    static char *qstringToChar(const QString &str);
-
-    /*!
      * @brief Checks the status of the path using stat().
      *
      * @param path Reference to path of which status is to be checked.


### PR DESCRIPTION
The method was returning a pointer to the temporary variable it was creating. I.e. already deleted when reaching the caller.

Besides bad, this was also quite unnecessary. qPrintable() should be good enough for the needs here.